### PR TITLE
fix nil logger issue (#1)

### DIFF
--- a/cmd/url-shortener/main.go
+++ b/cmd/url-shortener/main.go
@@ -93,6 +93,10 @@ func setupLogger(env string) *slog.Logger {
 		log = slog.New(
 			slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}),
 		)
+	default: // If env config is invalid, set prod settings by default due to security
+		log = slog.New(
+			slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}),
+		)
 	}
 
 	return log


### PR DESCRIPTION
Фикс первого issue, связанный с тем, что не предусмотрена невалидная/пустая env конфигурация. Логгер возвращался нулевым.

Теперь в таких случаях по умолчанию ставим prod конфигурацию, как это принято во многих библиотеках/фреймворках. 