### PR TITLE
fix unlocal log variable in handlers and middleware

### DIFF
--- a/internal/http-server/handlers/redirect/redirect.go
+++ b/internal/http-server/handlers/redirect/redirect.go
@@ -25,7 +25,7 @@ func New(log *slog.Logger, urlGetter URLGetter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		const op = "handlers.url.redirect.New"
 
-		log = log.With(
+		log := log.With(
 			slog.String("op", op),
 			slog.String("request_id", middleware.GetReqID(r.Context())),
 		)

--- a/internal/http-server/handlers/url/save/save.go
+++ b/internal/http-server/handlers/url/save/save.go
@@ -37,7 +37,7 @@ func New(log *slog.Logger, urlSaver URLSaver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		const op = "handlers.url.save.New"
 
-		log = log.With(
+		log := log.With(
 			slog.String("op", op),
 			slog.String("request_id", middleware.GetReqID(r.Context())),
 		)

--- a/internal/http-server/middleware/logger/logger.go
+++ b/internal/http-server/middleware/logger/logger.go
@@ -10,7 +10,7 @@ import (
 
 func New(log *slog.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		log = log.With(
+		log := log.With(
 			slog.String("component", "middleware/logger"),
 		)
 


### PR DESCRIPTION
Проблема описана [здесь](https://github.com/GolangLessons/url-shortener/issues/6#issue-1793222351) Там вылезает, в первой прикидке, утечка памяти и гонка. 