### PR TITLE
Improve pretty logger

### DIFF
--- a/cmd/url-shortener/main.go
+++ b/cmd/url-shortener/main.go
@@ -105,6 +105,7 @@ func setupLogger(env string) *slog.Logger {
 func setupPrettySlog() *slog.Logger {
 	handler := slogpretty.NewHandler(os.Stdout).
 		WithFieldsFormatJsonIndent().
-		WithLevel(slog.LevelDebug)
+		WithLevel(slog.LevelDebug).
+		WithUseLevelEmoji()
 	return slog.New(handler)
 }

--- a/cmd/url-shortener/main.go
+++ b/cmd/url-shortener/main.go
@@ -86,33 +86,24 @@ func main() {
 }
 
 func newLogger(env string) *slog.Logger {
-	var log *slog.Logger
-
 	switch env {
 	case envLocal:
-		log = newPrettySlog()
+		return slog.New(slogpretty.NewHandler().
+			WithLevel(slog.LevelDebug).
+			WithLevelEmoji().
+			WithAddSource().
+			WithTimeLayout("15:04:05"))
 	case envDev:
-		log = slog.New(
+		return slog.New(
 			slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}),
 		)
 	case envProd:
-		log = slog.New(
-			slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}),
-		)
-	default: // If env config is invalid, set prod settings by default due to security
-		log = slog.New(
+		return slog.New(
 			slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}),
 		)
 	}
-
-	return log
-}
-
-func newPrettySlog() *slog.Logger {
-	handler := slogpretty.NewHandler().
-		WithLevel(slog.LevelDebug).
-		WithLevelEmoji().
-		WithAddSource().
-		WithTimeLayout("15:04:05")
-	return slog.New(handler)
+	// If env config is invalid, set prod settings by default due to security
+	return slog.New(
+		slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}),
+	)
 }

--- a/cmd/url-shortener/main.go
+++ b/cmd/url-shortener/main.go
@@ -109,9 +109,10 @@ func newLogger(env string) *slog.Logger {
 }
 
 func newPrettySlog() *slog.Logger {
-	handler := slogpretty.NewHandler(os.Stdout).
+	handler := slogpretty.NewHandler().
 		WithLevel(slog.LevelDebug).
 		WithLevelEmoji().
-		WithAddSource()
+		WithAddSource().
+		WithTimeLayout("15:04:05")
 	return slog.New(handler)
 }

--- a/cmd/url-shortener/main.go
+++ b/cmd/url-shortener/main.go
@@ -73,7 +73,7 @@ func main() {
 	}
 
 	if err := srv.ListenAndServe(); err != nil {
-		log.Error("failed to start server")
+		log.Error("failed to start server: " + err.Error())
 	}
 
 	log.Error("server stopped")
@@ -103,13 +103,8 @@ func setupLogger(env string) *slog.Logger {
 }
 
 func setupPrettySlog() *slog.Logger {
-	opts := slogpretty.PrettyHandlerOptions{
-		SlogOpts: &slog.HandlerOptions{
-			Level: slog.LevelDebug,
-		},
-	}
-
-	handler := opts.NewPrettyHandler(os.Stdout)
-
+	handler := slogpretty.NewHandler(os.Stdout).
+		WithFieldsFormatJsonIndent().
+		WithLevel(slog.LevelDebug)
 	return slog.New(handler)
 }

--- a/cmd/url-shortener/main.go
+++ b/cmd/url-shortener/main.go
@@ -110,8 +110,8 @@ func newLogger(env string) *slog.Logger {
 
 func newPrettySlog() *slog.Logger {
 	handler := slogpretty.NewHandler(os.Stdout).
-		WithFieldsFormatJsonIndent().
 		WithLevel(slog.LevelDebug).
-		WithUseLevelEmoji()
+		WithLevelEmoji().
+		WithAddSource()
 	return slog.New(handler)
 }

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,0 +1,8 @@
+env: "local"
+storage_path: "./storage.db"
+http_server:
+  address: "127.0.0.1:50000"
+  timeout: 4s
+  idle_timeout: 30s
+  user: "Shabby8574"
+  password: "123"

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -6,3 +6,12 @@ http_server:
   idle_timeout: 30s
   user: "Shabby8574"
   password: "123"
+log:
+  slog:
+    add_source: true
+    level: "debug"
+    format: "pretty"
+    pretty:
+      fields_format: "json"
+      emoji: true
+      time_layout: "15:04:05"

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -5,3 +5,8 @@ http_server:
   timeout: 4s
   idle_timeout: 30s
   user: "Shabby8574"
+log:
+  slog:
+    level: "info"
+    add_source: true
+    format: "json"

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -53,7 +54,6 @@ require (
 	golang.org/x/text v0.8.0 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl/v2 v2.3.0 // indirect
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 }
 
 type HTTPServer struct {
-	Address     string        `yaml:"address" env-default:"localhost:8080"`
+	Address     string        `yaml:"address" env-default:"localhost:8080" env:"HTTP_SERVER_ADDR"`
 	Timeout     time.Duration `yaml:"timeout" env-default:"4s"`
 	IdleTimeout time.Duration `yaml:"idle_timeout" env-default:"60s"`
 	User        string        `yaml:"user" env-required:"true"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,26 +1,45 @@
 package config
 
 import (
+	"golang.org/x/exp/slog"
 	"log"
 	"os"
 	"time"
+	"url-shortener/internal/lib/logger/handlers/slogpretty"
 
 	"github.com/ilyakaznacheev/cleanenv"
 )
 
-type Config struct {
-	Env         string `yaml:"env" env-default:"local"`
-	StoragePath string `yaml:"storage_path" env-required:"true"`
-	HTTPServer  `yaml:"http_server"`
-}
+type (
+	Config struct {
+		HTTPServer  `yaml:"http_server"`
+		Env         string `yaml:"env" env-default:"local"`
+		StoragePath string `yaml:"storage_path" env-required:"true"`
+		Log         Log    `yaml:"log"`
+	}
+	HTTPServer struct {
+		Address     string        `yaml:"address" env-default:"localhost:8080" env:"HTTP_SERVER_ADDR"`
+		Timeout     time.Duration `yaml:"timeout" env-default:"4s"`
+		IdleTimeout time.Duration `yaml:"idle_timeout" env-default:"60s"`
+		User        string        `yaml:"user" env-required:"true"`
+		Password    string        `yaml:"password" env-required:"true" env:"HTTP_SERVER_PASSWORD"`
+	}
+	Log struct {
+		Slog Slog `yaml:"slog"`
+	}
+	Slog struct {
+		Level     slog.Level              `yaml:"level"`
+		AddSource bool                    `yaml:"add_source"`
+		Format    slogpretty.FieldsFormat `yaml:"format"` // json, text or pretty
+		Pretty    PrettyLog               `yaml:"pretty"`
+	}
 
-type HTTPServer struct {
-	Address     string        `yaml:"address" env-default:"localhost:8080" env:"HTTP_SERVER_ADDR"`
-	Timeout     time.Duration `yaml:"timeout" env-default:"4s"`
-	IdleTimeout time.Duration `yaml:"idle_timeout" env-default:"60s"`
-	User        string        `yaml:"user" env-required:"true"`
-	Password    string        `yaml:"password" env-required:"true" env:"HTTP_SERVER_PASSWORD"`
-}
+	PrettyLog struct {
+		FieldsFormat slogpretty.FieldsFormat `yaml:"fields_format"` // json, json-indent or yaml
+		Emoji        bool                    `yaml:"emoji"`
+		TimeLayout   string                  `yaml:"time_layout"`
+	}
+)
 
 func MustLoad() *Config {
 	configPath := os.Getenv("CONFIG_PATH")

--- a/internal/lib/logger/handlers/slogpretty/slogpretty.go
+++ b/internal/lib/logger/handlers/slogpretty/slogpretty.go
@@ -164,11 +164,7 @@ func recordFormatSource(r slog.Record) string {
 }
 
 func (f marshalFunc) formatFields(fields map[string]interface{}) (string, error) {
-	var (
-		b   []byte
-		err error
-	)
-	b, err = f(fields)
+	b, err := f(fields)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
![image](https://github.com/GolangLessons/url-shortener/assets/6129096/d6662994-6727-46a6-9a9c-2f82f97f3da2)
Golals:

- correct processing of structural logging groups
- correct implementation of the interface `interface { WithGroup(name string) slog.Handler }` in accordance with `slog` contract 
- additional logger options useful for local debugging

for example the following statement

`log.WithGroup("group1").WithGroup("group2").Info("msg", slog.Group("group3", slog.Group("group4", "k1", "v1", "k2", "v2")))`

produces something like the following output with the original version of the logger from the current main branch

```
[20:16:16.624] INFO: msg {
  "group3": [
    {
      "Key": "group4",
      "Value": {}
    }
  ]
}

```

and more meaningful output with corrected logger

`INFO  msg {"group1":{"group2":{"group3":{"group4":{"k1":"v1","k2":"v2"}}}}} main.go:31.main`

Pease don't forget to squash before merge

