### PR TITLE
fixed startup order

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,17 +9,18 @@ import (
 )
 
 type Config struct {
-	Env         string `yaml:"env" env-default:"local"`
-	StoragePath string `yaml:"storage_path" env-required:"true"`
-	HTTPServer  `yaml:"http_server"`
+	Env         string     `yaml:"env" env-default:"local"`
+	StoragePath string     `yaml:"storage_path" env-required:"true"`
+	HTTPServer  HTTPServer `yaml:"http_server"`
 }
 
 type HTTPServer struct {
-	Address     string        `yaml:"address" env-default:"localhost:8080"`
-	Timeout     time.Duration `yaml:"timeout" env-default:"4s"`
-	IdleTimeout time.Duration `yaml:"idle_timeout" env-default:"60s"`
-	User        string        `yaml:"user" env-required:"true"`
-	Password    string        `yaml:"password" env-required:"true" env:"HTTP_SERVER_PASSWORD"`
+	Address         string        `yaml:"address" env-default:"localhost:8080"`
+	Timeout         time.Duration `yaml:"timeout" env-default:"4s"`
+	IdleTimeout     time.Duration `yaml:"idle_timeout" env-default:"60s"`
+	ShutdownTimeout time.Duration `yaml:"shutdown_timeout" env-default:"10s"`
+	User            string        `yaml:"user" env-required:"true"`
+	Password        string        `yaml:"password" env-required:"true" env:"HTTP_SERVER_PASSWORD"`
 }
 
 func MustLoad() *Config {


### PR DESCRIPTION
Изменен порядок запуска http-сервера и прослушивания сигналов завершения. В случае если метод ListenAndServe завершался ошибкой, не в следствии выполнения Shutdown (например порт уже занят), программа зависала в ожидании сигнала SIGINT/SIGTERM.
Таймаут завершения перенесен в конфиг.
Устранена неоднозначность cfg.Address/cfg.HTTPServer.Address. Теперь к конфигурации http-сервера нужно всегда обращать через префикс HTTPServer.
Добавлено закрытие storage при завершении программы.
